### PR TITLE
blog-customizer

### DIFF
--- a/src/components/article-params-form/ArticleParamsForm.module.scss
+++ b/src/components/article-params-form/ArticleParamsForm.module.scss
@@ -16,6 +16,7 @@
 	display: flex;
 	flex-shrink: 0;
 	flex-direction: column;
+	gap: 30px;
 	box-sizing: border-box;
 	width: 616px;
 	height: auto;

--- a/src/components/article-params-form/ArticleParamsForm.tsx
+++ b/src/components/article-params-form/ArticleParamsForm.tsx
@@ -1,6 +1,7 @@
 import { ArrowButton } from 'src/ui/arrow-button';
 import { Button } from 'src/ui/button';
-import { useState, useRef } from 'react';
+import { Text } from 'src/ui/text';
+import { useState, useRef, useEffect } from 'react';
 import {
 	backgroundColors,
 	fontFamilyOptions,
@@ -26,6 +27,7 @@ type ArticleParamsFormProps = {
 };
 
 export const ArticleParamsForm = ({
+	currentSettings,
 	onApply,
 	onReset,
 }: ArticleParamsFormProps) => {
@@ -41,12 +43,11 @@ export const ArticleParamsForm = ({
 		onChange: setIsPanelOpen,
 	});
 
-	/*useEffect(() => {
+	useEffect(() => {
 		if (isPanelOpen) {
-			setInitialOnOpen({ ...currentSettings });
-			setTempSettings({ ...currentSettings })
+			setTempSettings({ ...currentSettings });
 		}
-	}, [isPanelOpen]);*/
+	}, [isPanelOpen, currentSettings]);
 
 	const handleApply = () => {
 		onApply(tempSettings);
@@ -66,75 +67,75 @@ export const ArticleParamsForm = ({
 				onClick={() => setIsPanelOpen((prev) => !prev)}
 			/>
 
-			{isPanelOpen && (
-				<aside
-					ref={panelRef}
-					className={clsx(
-						styles.container,
-						isPanelOpen && styles.container_open
-					)}>
-					<form className={styles.form} onSubmit={(e) => e.preventDefault()}>
-						<Select
-							options={fontFamilyOptions}
-							selected={tempSettings.fontFamilyOption}
-							onChange={(value) =>
-								setTempSettings({ ...tempSettings, fontFamilyOption: value })
-							}
-							title='Шрифт'
-						/>
-						<RadioGroup
-							name='fontsize'
-							options={fontSizeOptions}
-							selected={tempSettings.fontSizeOption}
-							onChange={(value) =>
-								setTempSettings({ ...tempSettings, fontSizeOption: value })
-							}
-							title='Размер шрифта'
-						/>
-						<Select
-							options={fontColors}
-							selected={tempSettings.fontColor}
-							onChange={(value) =>
-								setTempSettings({ ...tempSettings, fontColor: value })
-							}
-							title='Цвет шрифта'
-						/>
+			<aside
+				ref={panelRef}
+				className={clsx(styles.container, {
+					[styles.container_open]: isPanelOpen,
+				})}>
+				<form
+					className={styles.form}
+					onSubmit={(e) => {
+						e.preventDefault();
+						handleApply();
+					}}>
+					<Text weight={800} size={31} uppercase>
+						Задайте параметры
+					</Text>
+					<Select
+						options={fontFamilyOptions}
+						selected={tempSettings.fontFamilyOption}
+						onChange={(value) =>
+							setTempSettings({ ...tempSettings, fontFamilyOption: value })
+						}
+						title='Шрифт'
+					/>
+					<RadioGroup
+						name='fontsize'
+						options={fontSizeOptions}
+						selected={tempSettings.fontSizeOption}
+						onChange={(value) =>
+							setTempSettings({ ...tempSettings, fontSizeOption: value })
+						}
+						title='Размер шрифта'
+					/>
+					<Select
+						options={fontColors}
+						selected={tempSettings.fontColor}
+						onChange={(value) =>
+							setTempSettings({ ...tempSettings, fontColor: value })
+						}
+						title='Цвет шрифта'
+					/>
 
-						<Separator />
-						<Select
-							options={backgroundColors}
-							selected={tempSettings.backgroundColor}
-							onChange={(value) =>
-								setTempSettings({ ...tempSettings, backgroundColor: value })
-							}
-							title='Цвет фона'
-						/>
-						<Select
-							options={contentWidthArr}
-							selected={tempSettings.contentWidth}
-							onChange={(value) =>
-								setTempSettings({ ...tempSettings, contentWidth: value })
-							}
-							title='Ширина контента'
-						/>
+					<Separator />
+					<Select
+						options={backgroundColors}
+						selected={tempSettings.backgroundColor}
+						onChange={(value) =>
+							setTempSettings({ ...tempSettings, backgroundColor: value })
+						}
+						title='Цвет фона'
+					/>
+					<Select
+						options={contentWidthArr}
+						selected={tempSettings.contentWidth}
+						onChange={(value) =>
+							setTempSettings({ ...tempSettings, contentWidth: value })
+						}
+						title='Ширина контента'
+					/>
 
-						<div className={styles.bottomContainer}>
-							<Button
-								title='Сбросить'
-								htmlType='button'
-								type='clear'
-								onClick={handleReset}
-							/>
-							<Button
-								title='Применить'
-								htmlType='button'
-								type='apply'
-								onClick={handleApply}
-							/>
-						</div>
-					</form>
-				</aside>
-			)}
+					<div className={styles.bottomContainer}>
+						<Button
+							title='Сбросить'
+							htmlType='button'
+							type='clear'
+							onClick={handleReset}
+						/>
+						<Button title='Применить' htmlType='submit' type='apply' />
+					</div>
+				</form>
+			</aside>
 		</>
 	);
 };

--- a/src/components/article-params-form/ArticleParamsForm.tsx
+++ b/src/components/article-params-form/ArticleParamsForm.tsx
@@ -1,20 +1,140 @@
 import { ArrowButton } from 'src/ui/arrow-button';
 import { Button } from 'src/ui/button';
-
+import { useState, useRef } from 'react';
+import {
+	backgroundColors,
+	fontFamilyOptions,
+	fontSizeOptions,
+	fontColors,
+	contentWidthArr,
+	defaultArticleState,
+	ArticleStateType,
+} from 'src/constants/articleProps';
+import { useOutsideClickClose } from 'src/ui/select/hooks/useOutsideClickClose';
 import styles from './ArticleParamsForm.module.scss';
+import { clsx } from 'clsx';
+import { Select } from 'src/ui/select';
+import { RadioGroup } from 'src/ui/radio-group';
+import { Separator } from 'src/ui/separator';
 
-export const ArticleParamsForm = () => {
+export type ArticleState = ArticleStateType;
+
+type ArticleParamsFormProps = {
+	currentSettings: ArticleState;
+	onApply: (settings: ArticleState) => void;
+	onReset: () => void;
+};
+
+export const ArticleParamsForm = ({
+	onApply,
+	onReset,
+}: ArticleParamsFormProps) => {
+	const [tempSettings, setTempSettings] =
+		useState<ArticleState>(defaultArticleState);
+	const [isPanelOpen, setIsPanelOpen] = useState<boolean>(false);
+
+	const panelRef = useRef<HTMLDivElement>(null);
+
+	useOutsideClickClose({
+		isOpen: isPanelOpen,
+		rootRef: panelRef,
+		onChange: setIsPanelOpen,
+	});
+
+	/*useEffect(() => {
+		if (isPanelOpen) {
+			setInitialOnOpen({ ...currentSettings });
+			setTempSettings({ ...currentSettings })
+		}
+	}, [isPanelOpen]);*/
+
+	const handleApply = () => {
+		onApply(tempSettings);
+		setIsPanelOpen(false);
+	};
+
+	const handleReset = () => {
+		setTempSettings({ ...defaultArticleState });
+		onReset();
+		setIsPanelOpen(false);
+	};
+
 	return (
 		<>
-			<ArrowButton isOpen={false} onClick={() => {}} />
-			<aside className={styles.container}>
-				<form className={styles.form}>
-					<div className={styles.bottomContainer}>
-						<Button title='Сбросить' htmlType='reset' type='clear' />
-						<Button title='Применить' htmlType='submit' type='apply' />
-					</div>
-				</form>
-			</aside>
+			<ArrowButton
+				isOpen={isPanelOpen}
+				onClick={() => setIsPanelOpen((prev) => !prev)}
+			/>
+
+			{isPanelOpen && (
+				<aside
+					ref={panelRef}
+					className={clsx(
+						styles.container,
+						isPanelOpen && styles.container_open
+					)}>
+					<form className={styles.form} onSubmit={(e) => e.preventDefault()}>
+						<Select
+							options={fontFamilyOptions}
+							selected={tempSettings.fontFamilyOption}
+							onChange={(value) =>
+								setTempSettings({ ...tempSettings, fontFamilyOption: value })
+							}
+							title='Шрифт'
+						/>
+						<RadioGroup
+							name='fontsize'
+							options={fontSizeOptions}
+							selected={tempSettings.fontSizeOption}
+							onChange={(value) =>
+								setTempSettings({ ...tempSettings, fontSizeOption: value })
+							}
+							title='Размер шрифта'
+						/>
+						<Select
+							options={fontColors}
+							selected={tempSettings.fontColor}
+							onChange={(value) =>
+								setTempSettings({ ...tempSettings, fontColor: value })
+							}
+							title='Цвет шрифта'
+						/>
+
+						<Separator />
+						<Select
+							options={backgroundColors}
+							selected={tempSettings.backgroundColor}
+							onChange={(value) =>
+								setTempSettings({ ...tempSettings, backgroundColor: value })
+							}
+							title='Цвет фона'
+						/>
+						<Select
+							options={contentWidthArr}
+							selected={tempSettings.contentWidth}
+							onChange={(value) =>
+								setTempSettings({ ...tempSettings, contentWidth: value })
+							}
+							title='Ширина контента'
+						/>
+
+						<div className={styles.bottomContainer}>
+							<Button
+								title='Сбросить'
+								htmlType='button'
+								type='clear'
+								onClick={handleReset}
+							/>
+							<Button
+								title='Применить'
+								htmlType='button'
+								type='apply'
+								onClick={handleApply}
+							/>
+						</div>
+					</form>
+				</aside>
+			)}
 		</>
 	);
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,5 @@
 import { createRoot } from 'react-dom/client';
-import { StrictMode, CSSProperties } from 'react';
+import { StrictMode, CSSProperties, useState, useCallback } from 'react';
 import clsx from 'clsx';
 
 import { Article } from './components/article/Article';
@@ -9,23 +9,40 @@ import { defaultArticleState } from './constants/articleProps';
 import './styles/index.scss';
 import styles from './styles/index.module.scss';
 
+type ArticleState = typeof defaultArticleState;
+
 const domNode = document.getElementById('root') as HTMLDivElement;
 const root = createRoot(domNode);
 
 const App = () => {
+	const [currentSettings, setCurrentSettings] =
+		useState<ArticleState>(defaultArticleState);
+
+	const handleApply = useCallback((settings: ArticleState) => {
+		setCurrentSettings(settings);
+	}, []);
+
+	const handleReset = useCallback(() => {
+		setCurrentSettings(defaultArticleState);
+	}, []);
+
 	return (
 		<main
 			className={clsx(styles.main)}
 			style={
 				{
-					'--font-family': defaultArticleState.fontFamilyOption.value,
-					'--font-size': defaultArticleState.fontSizeOption.value,
-					'--font-color': defaultArticleState.fontColor.value,
-					'--container-width': defaultArticleState.contentWidth.value,
-					'--bg-color': defaultArticleState.backgroundColor.value,
+					'--font-family': currentSettings.fontFamilyOption.value,
+					'--font-size': currentSettings.fontSizeOption.value,
+					'--font-color': currentSettings.fontColor.value,
+					'--container-width': currentSettings.contentWidth.value,
+					'--bg-color': currentSettings.backgroundColor.value,
 				} as CSSProperties
 			}>
-			<ArticleParamsForm />
+			<ArticleParamsForm
+				currentSettings={currentSettings}
+				onApply={handleApply}
+				onReset={handleReset}
+			/>
 			<Article />
 		</main>
 	);


### PR DESCRIPTION
Реализована панель кастомизации:
При нажатии на «стрелку» открывается сайдбар с настройками, при повторном нажатии или клике вне сайдбар закрывается.
При изменении настроек в сайдбаре они не применяются сразу.
После нажатия на «применить» стили применяются к статье.
При нажатии «сбросить» настройки в форме сбрасываются на начальные, которые были при открытии страницы, и стили применяются к статье.
Настройки устанавливаются через CSS-переменные, которые уже есть в стилях и установлены в коде в дефолтные значения.